### PR TITLE
Always reset server side collections on pagination

### DIFF
--- a/lib/collections/server_collection.coffee
+++ b/lib/collections/server_collection.coffee
@@ -43,15 +43,14 @@ class @Teeble.ServerCollection extends Backbone.Paginator.requestPager
             @lastSortColumn = @sortColumn
             @sortColumn = column
             @sortDirection = direction
-            @pager(reset: true)
+            @pager()
             @info()
 
-    pager: (options = {}) =>
+    pager: =>
         if @lastSortColumn isnt @sortColumn and @sortColumn?
             @currentPage = 1;
             @lastSortColumn = @sortColumn
 
-        options.reset = true
-        super(options)
+        super({reset: true})
 
         @info()


### PR DESCRIPTION
Here's the deal:

For server-side collections, if we do not do this, the following things won't happen automatically:
1) Proper pagination rendering
2) Removal of the empty message
3) When paging, the previous "page" of data will not be removed from the table

Simply calling reset fixes all of these issues.

@marcneuwirth @b-ash 
